### PR TITLE
Update to work with current version of zabbix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Zabbix Template Module NFS version 1.0.3
 
-Tested on Zabbix 4.4
+Tested on Zabbix 5.2
 
 # Introduction
 Template for zabbix to check nfs share availability using external script.
@@ -26,33 +26,34 @@ On linux NFS server you may need to install **rpcbind** service to get informati
 
 ## Content
 The template installation require 2 files:
-* **frogg_nfs_check.sh** Zabbix external script
-* **frogg_nfs_check.xml** Zabbix template configuration
+* `frogg_nfs_check.sh` Zabbix external script
+* `frogg_nfs_check.xml` Zabbix template configuration
 
 ## External script
 
-You need to place the script **frogg_nfs_check.sh** into zabbix external forlder **externalscripts** (by default in **/usr/lib/zabbix/externalscripts**) 
-
-You can find the external script folder in Zabbix configuration file **zabbix_server.conf** (by default in **/etc/zabbix/zabbix_server.conf**)
+Place the `frogg_nfs_check.sh` in `/etc/zabbix/externalscripts`. If you choose another location for your external scripts, you have to edit the `userparameter_frogg_nfs_check.conf` accordingly.
 
 You will need to add execute permission on the script
-```bash
+```console
 chmod +x frogg_nfs_check.sh 
 ```
 
+Finally add the `userparameter_frogg_nfs_check.conf` to `/etc/zabbix/zabbix_agentd.conf.d/` or any other of your configuration directories, that are specified in the configuration file of the zabbix agent (default `/etc/zabbix/zabbix_agentd.conf`).
+
 ### Testing the installation
+
 You can run the command:
 - To Test NFS version
-```bash
-./frogg_nfs_check.sh version 192.168.0.1
+```
+./frogg_nfs_check.sh version <ip-of-server>
 ```
 - To Test NFS share
-```bash
-./frogg_nfs_check.sh share 192.168.0.1 /nfsShare1:/nfsShare2:/nfsShare3
+```
+./frogg_nfs_check.sh share <ip-of-server> "/nfsShare1,/nfsShare2,/nfsShare3"
 ```
 ## Template
 
-Then you need to import the **frogg_nfs_check.xml** template configuration file in the zabbix web interface in **Template** tab using the import button
+Then you need to import the `frogg_nfs_check.xml` template configuration file in the zabbix web interface in **Template** tab using the import button
 
 # Host configuration
 The template use 2 macros :
@@ -60,7 +61,7 @@ The template use 2 macros :
 MACRO | Description
 ----- | -----------
 {$NFSVERSION} | the NFS version that should be returned by the server
-{$NFSSHARES} | the list of NFS shares that should be available, to set multiple shares they must be separated by **;**
+{$NFSSHARES} | the list of NFS shares that should be available, to set multiple shares they must be separated by `,` 
 
 Exemple:
 ![Zabbix NFS configuration sample](https://tool.frogg.fr/upload/github/zabbix-nfs/macros.png)
@@ -71,16 +72,16 @@ Exemple:
 # Template triggers
 ![Zabbix NFS Template triggers](https://tool.frogg.fr/upload/github/zabbix-nfs/triggers.png)
 
-# Debuging
+# Debugging
 
 Going further...This step is working with most of externals scripts
 
 If you got troubles getting an external script working, first :
-1. Check the Zabbix tab **Monitoring > lastest data**
+1. Check the Zabbix tab **Monitoring > latest data**
 If you select an host, you should see all items linked to it, check for your item and you should see the lasted data linked to it.
 If it appear in gray (disabled) that mean there is something wrong with the external script (rights, path, arguments ...)
 To find more about it you can check logs
-2. By default the logs are in **/var/log/zabbix/zabbix_server.log** or you can find the log path in Zabbix configuration file **zabbix_server.conf** (by default **/etc/zabbix/zabbix_server.conf**)
+2. By default the logs are in `/var/log/zabbix/zabbix_server.log` or you can find the log path in Zabbix configuration file `zabbix_server.conf` (by default `/etc/zabbix/zabbix_server.conf`)
 
 To get the last log lines you can use for example:
 ```bash

--- a/frogg_nfs_check.sh
+++ b/frogg_nfs_check.sh
@@ -70,7 +70,7 @@ NFSDATA=$(showmount -e $1 2> /dev/null)
 IFS=$'\n' read -rd '' -a NFSDATAS <<< "$NFSDATA"
 
 # Get NFS share set as params and store it as an array
-SHARES=$(echo $2 | tr ";" "\n")
+SHARES=$(echo $2 | tr "," "\n")
 
 #For each NFS share test if exist in server NFS share list
 for SHARE in $SHARES

--- a/frogg_nfs_check.xml
+++ b/frogg_nfs_check.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>4.4</version>
-    <date>2020-03-08T13:52:09Z</date>
+    <version>5.2</version>
+    <date>2021-03-14T13:31:06Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -12,8 +12,8 @@
     </groups>
     <templates>
         <template>
-            <template>Template Module NFS</template>
-            <name>Template Module NFS</name>
+            <template>NFS Share</template>
+            <name>NFS Share</name>
             <description>This template check NFS version and shares</description>
             <groups>
                 <group>
@@ -31,12 +31,16 @@
             <items>
                 <item>
                     <name>Check NFS share</name>
-                    <type>EXTERNAL</type>
-                    <key>frogg_nfs_check.sh[share,{HOST.CONN},{$NFSSHARES}]</key>
+                    <key>nfsshare.share[{HOST.CONN},{$NFSSHARES}]</key>
                     <delay>2m</delay>
                     <history>7d</history>
                     <trends>0</trends>
                     <value_type>TEXT</value_type>
+                    <applications>
+                        <application>
+                            <name>NFS share</name>
+                        </application>
+                    </applications>
                     <triggers>
                         <trigger>
                             <expression>{strlen()}&gt;0</expression>
@@ -47,11 +51,16 @@
                 </item>
                 <item>
                     <name>Check NFS version</name>
-                    <type>EXTERNAL</type>
-                    <key>frogg_nfs_check.sh[version,{HOST.CONN}]</key>
+                    <key>nfsshare.version[{HOST.CONN}]</key>
                     <delay>30m</delay>
                     <history>7d</history>
+                    <trends>0</trends>
                     <value_type>FLOAT</value_type>
+                    <applications>
+                        <application>
+                            <name>NFS share</name>
+                        </application>
+                    </applications>
                     <triggers>
                         <trigger>
                             <expression>{last()}=0</expression>
@@ -66,6 +75,18 @@
                     </triggers>
                 </item>
             </items>
+            <macros>
+                <macro>
+                    <macro>{$NFSSHARES}</macro>
+                    <value>/nfsshare</value>
+                    <description>List of shares seperated by ;</description>
+                </macro>
+                <macro>
+                    <macro>{$NFSVERSION}</macro>
+                    <value>4</value>
+                    <description>NFS version expected</description>
+                </macro>
+            </macros>
         </template>
     </templates>
 </zabbix_export>

--- a/frogg_nfs_check.xml
+++ b/frogg_nfs_check.xml
@@ -79,7 +79,7 @@
                 <macro>
                     <macro>{$NFSSHARES}</macro>
                     <value>/nfsshare</value>
-                    <description>List of shares seperated by ;</description>
+                    <description>List of shares separated by ,</description>
                 </macro>
                 <macro>
                     <macro>{$NFSVERSION}</macro>

--- a/userparameter_frogg_nfs_check.conf
+++ b/userparameter_frogg_nfs_check.conf
@@ -1,0 +1,2 @@
+UserParameter=nfsshare.version[*],/etc/zabbix/externalscripts/frogg_nfs_check.sh version $1
+UserParameter=nfsshare.share[*],/etc/zabbix/externalscripts/frogg_nfs_check.sh share $1 $2


### PR DESCRIPTION
I noticed some problems when using this extension, so I did some modifications to make it work with the current version (5.2) of zabbix. It's works nice for me now.

# Changelog
- Tranformed to type "zabbix agent" from "External checks" -> Remake of the template
- Added userparameter file
- Changed separator to "," instead of ";", because zabbix server won't accept any ";" in the parameters
- Updated Readme